### PR TITLE
Support off-chain TLSA records (AIA only)

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ var (
 	grandparentKey  = flag.String("grandparent-key", "", "(Optional) Path to existing CA private key to sign CA cert with")
 	grandparentChain = flag.String("grandparent-chain", "", "(Optional) Path to existing CA cert chain to sign CA cert with")
 	sigs = flag.String("sigs", "", "(Optional) Path to existing Namecoin message signatures to staple (saves blockchain space)")
-	useAIA *bool
+	useAIA bool
 )
 
 func publicKey(priv any) any {
@@ -75,7 +75,7 @@ func main() {
 		log.Fatalf("Missing required --host parameter")
 	}
 
-	*useAIA = *parentChain == "" && *grandparentChain == ""
+	useAIA = *parentChain == "" && *grandparentChain == ""
 
 	var priv any
 	var err error

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ var (
 	parentChain = flag.String("parent-chain", "", "(Optional) Path to existing CA cert chain to sign end-entity cert with")
 	grandparentKey  = flag.String("grandparent-key", "", "(Optional) Path to existing CA private key to sign CA cert with")
 	grandparentChain = flag.String("grandparent-chain", "", "(Optional) Path to existing CA cert chain to sign CA cert with")
+	sigs = flag.String("sigs", "", "(Optional) Path to existing Namecoin message signatures to staple (saves blockchain space)")
 	useAIA *bool
 )
 
@@ -211,5 +212,11 @@ func main() {
 
 	writeChain()
 
-	log.Print("SUCCESS.  Place chain.pem and key.pem in your HTTPS server, and place the contents of \"namecoin.json\" in the \"tls\" field for \"*." + *host + "\".")
+	if *sigs == "" && *grandparentKey == "" {
+		log.Print("SUCCESS. You have two deployment options.")
+		log.Print("Option 1 (wastes blockchain space): Place chain.pem and key.pem in your HTTPS server, and place the contents of \"namecoin.json\" in the \"tls\" field for \"*." + *host + "\".")
+		log.Print("Option 2 (conserves blockchain space): sign \"caAIAMessage.txt\" with your Namecoin wallet. Then re-run ncgencert with the \"-grandparent-key\" and \"-sigs\" parameters to generate your final certificate chain; no blockchain transaction is necessary.")
+	} else {
+		log.Print("SUCCESS. Place chain.pem and key.pem in your HTTPS server.")
+	}
 }

--- a/parent.go
+++ b/parent.go
@@ -205,6 +205,17 @@ func getParent() (x509.Certificate, any) {
 		// and listing an HTTPS URL can cause them to not chase the HTTP URL.
 		aiaBaseURL := "aia.x--nmc.bit/aia"
 		aiaURL := aiaBaseURL + "?domain=" + *host + "&pubb64=" + aiaPubStr
+
+		// Attach sigs if requested
+		if *sigs != "" {
+			sigsBytes, err := ioutil.ReadFile(*sigs)
+			if err != nil {
+				log.Fatalf("Failed to read stapled sigs: %v", err)
+			}
+
+			aiaURL = aiaURL + "&sigs=" + string(sigsBytes)
+		}
+
 		template.IssuingCertificateURL = []string{"http://" + aiaURL}
 
 		applyPiDomainCA(&template)

--- a/parent.go
+++ b/parent.go
@@ -34,6 +34,7 @@ import (
 	"log"
 	"math/big"
 	//"net"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -204,7 +205,7 @@ func getParent() (x509.Certificate, any) {
 		// Support only HTTP AIA.  HTTPS is not supported by major TLS clients,
 		// and listing an HTTPS URL can cause them to not chase the HTTP URL.
 		aiaBaseURL := "aia.x--nmc.bit/aia"
-		aiaURL := aiaBaseURL + "?domain=" + *host + "&pubb64=" + aiaPubStr
+		aiaURL := aiaBaseURL + "?domain=" + url.QueryEscape(*host) + "&pubb64=" + url.QueryEscape(aiaPubStr)
 
 		// Attach sigs if requested
 		if *sigs != "" {
@@ -213,7 +214,7 @@ func getParent() (x509.Certificate, any) {
 				log.Fatalf("Failed to read stapled sigs: %v", err)
 			}
 
-			aiaURL = aiaURL + "&sigs=" + string(sigsBytes)
+			aiaURL = aiaURL + "&sigs=" + url.QueryEscape(string(sigsBytes))
 		}
 
 		template.IssuingCertificateURL = []string{"http://" + aiaURL}

--- a/parent.go
+++ b/parent.go
@@ -191,7 +191,7 @@ func getParent() (x509.Certificate, any) {
 	var aiaParent x509.Certificate
 	var aiaParentPriv any
 
-	if *useAIA {
+	if useAIA {
 		aiaParent, aiaParentPriv = getAIAParent()
 
 		aiaPubBytes, err := x509.MarshalPKIXPublicKey(publicKey(aiaParentPriv))


### PR DESCRIPTION
* Adds support for stapling a Namecoin message signature.
* This avoids the need for any on-chain TLSA records, saving some on-chain space.
* The signature can be revoked by transferring the name to a new Namecoin address.
* Address reuse is required if you want to update/renew your name *without* revoking the signature.
* Bitcoin Core only supports P2PKH addresses for this purpose.
* Electrum supports P2PKH and P2WPKH addresses.
* Smart contract addresses (e.g. multisig) are not currently supported by either Bitcoin Core or Electrum.
* This feature is currently AIA-only. PKCS#11 support will come later.